### PR TITLE
Trigger connection error handler on socket error event

### DIFF
--- a/src/signalR.js
+++ b/src/signalR.js
@@ -1731,6 +1731,10 @@ jQueryShim.ajax = ajax;
 					}
 				};
 
+				connection.socket.onerror = function (error) {
+					$(connection).triggerHandler(events.onError, [error]);
+				}
+
 				connection.socket.onclose = function (event) {
 					var error;
 


### PR DESCRIPTION
When the `onerror` event handler of the websocket is called the error
gets passed on via trigger handler, allowing to handle the error from
the users side. This is useful because for example when the network connection is interrupted, an error gets thrown and might crash the node process. Because of the async websocket nature `.onclose` would be called after the process crashed, thus not allowing to handle the error event in a reasonable manner.